### PR TITLE
Use negated properties instead of activeByDefault for locker profile

### DIFF
--- a/src/main/resources/io/mvnpm/maven/locker/mojos/locker-profile.xml
+++ b/src/main/resources/io/mvnpm/maven/locker/mojos/locker-profile.xml
@@ -6,7 +6,13 @@
         <profile>
             <id>{lockerProfile}</id>
             <activation>
+                {#if useNegatedProp}
+                <property>
+                    <name>!unlocked</name>
+                </property>
+                {#else}
                 <activeByDefault>true</activeByDefault>
+                {/if}
             </activation>
             <dependencyManagement>
                 <dependencies>


### PR DESCRIPTION
`activeByDefault` profiles are not enabled when another profile is used, using a negated property '!unlocked' makes it easier to disable and guaranty it will be enabled even when another profile is enabled.

The drawback is that other activeByDefault profiles will be ignored, the locker prints a warning in that case when locking.